### PR TITLE
Stabilize tests and fix stylesheet path casing

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Learning Biology For Life</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="Style.css" />
   </head>
   <body>
     <main>

--- a/logic.test.js
+++ b/logic.test.js
@@ -1,16 +1,19 @@
 /**
  * Unit tests for extracted Blogger Template logic
- * Framework: Jest with JSDOM
+ * Framework: node:test
  */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
 
 // Logic extracted from the theme XML
 const pikiShortcode = (t, r) => {
-  const n = Array.from(t.matchAll(/(?:(#[a-zA-Z]{0,})=\(([^\)]+)\))/g)).find((t => t[1].split("#")[1] === r));
+  const n = Array.from(t.matchAll(/(?:(#[a-zA-Z]{0,})=\(([^\)]+)\))/g)).find((t => t[1].split('#')[1] === r));
   return !!n && n[2];
 };
 
 function get_text(e) {
-  let ret = "";
+  let ret = '';
   for (var t = e.childNodes.length, n = 0; n < t; n++) {
     var o = e.childNodes[n];
     // nodeType 8 is a Comment, nodeType 1 is an Element
@@ -21,39 +24,34 @@ function get_text(e) {
   return ret;
 }
 
-describe('Blogger Template Utility Logic', () => {
-  
-  describe('pikiShortcode()', () => {
-    test('should extract value for a given key in complex shortcode strings', () => {
-      const shortcodeStr = "#buttons=(Ok, Go it!) #days=(20) #type=(blogger)";
-      expect(pikiShortcode(shortcodeStr, 'buttons')).toBe('Ok, Go it!');
-      expect(pikiShortcode(shortcodeStr, 'days')).toBe('20');
-      expect(pikiShortcode(shortcodeStr, 'type')).toBe('blogger');
-    });
+test('pikiShortcode() extracts values for valid keys', () => {
+  const shortcodeStr = '#buttons=(Ok, Go it!) #days=(20) #type=(blogger)';
+  assert.equal(pikiShortcode(shortcodeStr, 'buttons'), 'Ok, Go it!');
+  assert.equal(pikiShortcode(shortcodeStr, 'days'), '20');
+  assert.equal(pikiShortcode(shortcodeStr, 'type'), 'blogger');
+});
 
-    test('should return false when a key does not exist', () => {
-      const shortcodeStr = "#buttons=(Ok, Go it!)";
-      expect(pikiShortcode(shortcodeStr, 'missing')).toBe(false);
-    });
+test('pikiShortcode() returns false for unknown keys', () => {
+  const shortcodeStr = '#buttons=(Ok, Go it!)';
+  assert.equal(pikiShortcode(shortcodeStr, 'missing'), false);
+});
 
-    test('should handle empty or malformed strings gracefully', () => {
-      expect(pikiShortcode("", "any")).toBe(false);
-      expect(pikiShortcode("just plain text without markers", "any")).toBe(false);
-    });
-  });
+test('pikiShortcode() handles empty and malformed strings', () => {
+  assert.equal(pikiShortcode('', 'any'), false);
+  assert.equal(pikiShortcode('just plain text without markers', 'any'), false);
+});
 
-  describe('get_text()', () => {
-    test('should recursively extract all text from nested nodes while ignoring comments', () => {
-      // Create a mock DOM structure
-      const container = document.createElement('div');
-      container.innerHTML = `
-        <p>Part 1 <span>Nested Part</span></p>
-        <!-- This comment should be ignored -->
-        <div>Part 2</div>
-      `;
-      
-      const extracted = get_text(container).replace(/\s+/g, ' ').trim();
-      expect(extracted).toBe('Part 1 Nested Part Part 2');
-    });
-  });
+test('get_text() recursively extracts text and ignores comments', () => {
+  const textNode = (value) => ({ nodeType: 3, nodeValue: value, childNodes: [] });
+  const commentNode = (value) => ({ nodeType: 8, nodeValue: value, childNodes: [] });
+  const elementNode = (children = []) => ({ nodeType: 1, nodeValue: null, childNodes: children });
+
+  const container = elementNode([
+    elementNode([textNode('Part 1 '), elementNode([textNode('Nested Part')])]),
+    commentNode(' This comment should be ignored '),
+    elementNode([textNode(' Part 2')]),
+  ]);
+
+  const extracted = get_text(container).replace(/\s+/g, ' ').trim();
+  assert.equal(extracted, 'Part 1 Nested Part Part 2');
 });


### PR DESCRIPTION
### Motivation
- Ensure unit tests run in a minimal environment without adding Jest or JSDOM dependencies by using the built-in Node test runner.
- Remove brittle browser-dependent test code so logic can be validated deterministically in CI and local developer setups.
- Prevent runtime asset load failures on case-sensitive filesystems by aligning the HTML stylesheet reference with the repository file name.

### Description
- Migrated `logic.test.js` from Jest-style globals to use Node's built-in `node:test` and `assert` APIs so tests run without additional test framework setup.
- Replaced use of `document.createElement`/JSDOM in the `get_text` test with a lightweight mocked node tree that preserves the same validation behavior.
- Fixed the stylesheet link in `Index.html` from `style.css` to `Style.css` to match the actual filename and avoid case-sensitivity issues.
- Minor test data adjustment to ensure spacing in the mocked nodes produces the expected normalized output from `get_text`.

### Testing
- Ran `node --test logic.test.js` initially which failed due to Jest-style globals being used by the original test file.
- After migrating tests and fixing the mocked nodes, ran `node --test logic.test.js` again and all tests passed (4/4).
- Ran `node --version` and `npm --version` as environment sanity checks during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a30a9a788332a2e6d933b738d2ac)